### PR TITLE
Changing http to https links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repo contains the NottsJS Website and assets.
 
-http://nottsjs.org
+https://nottsjs.org
 
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/nottsjs/discuss)

--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -7,7 +7,7 @@
     <meta name="description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area.">
     <meta property="og:title" content="NottsJS - Nottingham's Javascript Meetup">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://nottsjs.org">
+    <meta property="og:url" content="https://nottsjs.org">
     <meta property="og:image" content="https://raw.githubusercontent.com/nottsjs/nottsjs.github.io/master/img/logo.png">
     <meta property="og:site_name" content="NottsJS - Nottingham's Javascript Meetup">
     <meta property="og:description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area.">
@@ -17,7 +17,7 @@
     <meta name="twitter:title" content="NottsJS - Nottingham's Javascript Meetup" />
     <meta name="twitter:image" content="https://raw.githubusercontent.com/nottsjs/nottsjs.github.io/master/img/logo.png" />
     <meta name="twitter:description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area." />
-    <meta name="twitter:url" content="http://www.nottsjs.org">
+    <meta name="twitter:url" content="https://www.nottsjs.org">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
     <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area.">
     <meta property="og:title" content="NottsJS - Nottingham's Javascript Meetup">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://nottsjs.org">
+    <meta property="og:url" content="https://nottsjs.org">
     <meta property="og:image" content="https://raw.githubusercontent.com/nottsjs/nottsjs.github.io/master/img/logo.png">
     <meta property="og:site_name" content="NottsJS - Nottingham's Javascript Meetup">
     <meta property="og:description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area.">
@@ -17,7 +17,7 @@
     <meta name="twitter:title" content="NottsJS - Nottingham's Javascript Meetup" />
     <meta name="twitter:image" content="https://raw.githubusercontent.com/nottsjs/nottsjs.github.io/master/img/logo.png" />
     <meta name="twitter:description" content="NottsJS is a meetup for developers and anyone else interested in development. We meet every 2nd Wednesday of the month to talk about Node, Javascript, Full Stack development in the Nottingham area." />
-    <meta name="twitter:url" content="http://www.nottsjs.org">
+    <meta name="twitter:url" content="https://www.nottsjs.org">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.0/css/materialize.min.css">
     <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
@@ -50,7 +50,7 @@
           <h5 class="header col s12 light"><a class="black-text" href="https://goo.gl/maps/y5ChRcdFetw">34 Stoney Street, NG1 1NB</a></h5>
         </div>
         <div class="row center">
-          <a href="http://www.meetup.com/NottsJS/events/227799334/" id="download-button" class="btn-large waves-effect waves-light yellow black-text">Book your ticket now</a>
+          <a href="https://www.meetup.com/NottsJS/events/227799334/" id="download-button" class="btn-large waves-effect waves-light yellow black-text">Book your ticket now</a>
         </div>
         <div class="row center">
           <a href="https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NzRubjJzNzdub2pvOGxjMjJxN290ZGczYm8gNjIzYzZyZzY1OWpramlxMTF1dnF0djVyOTRAZw&tmsrc=623c6rg659jkjiq11uvqtv5r94%40group.calendar.google.com" class="black-text">Google Calendar</a>
@@ -123,12 +123,12 @@
         <div class="row center">
           <h4>Sponsored by</h4>
           <div class="col s-12 m4 offset-m2">
-            <a href="http://www.wearejh.com/" target="_blank">
+            <a href="https://www.wearejh.com/" target="_blank">
               <img src="img/jhlogo.png" height="80">
             </a>
           </div>
           <div class="col s-12 m4">
-            <a href="http://rebelrecruitment.co.uk/" target="_blank">
+            <a href="https://rebelrecruitment.co.uk/" target="_blank">
               <img src="img/rebel-logo.png" height="80">
             </a>
           </div>


### PR DESCRIPTION
All pages support `https` in that they are not broken. Both JH and Rebel redirect back to http but they can fix upstream.

Redirect to https from http would be worth adding in your cloudflare config.